### PR TITLE
feat: Add public map-data and heatmap-data endpoints

### DIFF
--- a/src/app/api/public/heatmap-data/route.ts
+++ b/src/app/api/public/heatmap-data/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/db';
+import { beneficiaries } from '@/db/schema/beneficiaries';
+import { eq, and, or, isNull, gt, sql } from 'drizzle-orm';
+
+const JITTER_RANGE = 0.003; // ~300 meter max offset
+const INTENSITY = 1.0;
+
+export async function GET() {
+  try {
+    const result = await db
+      .select({
+        latitude: beneficiaries.latitude,
+        longitude: beneficiaries.longitude,
+      })
+      .from(beneficiaries)
+      .where(
+        and(
+          eq(beneficiaries.status, 'verified'),
+          or(
+            isNull(beneficiaries.expiresAt),
+            gt(beneficiaries.expiresAt, sql`NOW()`)
+          )
+        )
+      );
+
+    const data: number[][] = result.map((row) => {
+      const jitterLat = (Math.random() - 0.5) * 2 * JITTER_RANGE;
+      const jitterLng = (Math.random() - 0.5) * 2 * JITTER_RANGE;
+      return [
+        row.latitude + jitterLat,
+        row.longitude + jitterLng,
+        INTENSITY,
+      ];
+    });
+
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error) {
+    console.error('Public heatmap data error:', error);
+    return NextResponse.json(
+      { error: 'Gagal memuat data heatmap' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/public/map-data/route.ts
+++ b/src/app/api/public/map-data/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/db';
+import { beneficiaries } from '@/db/schema/beneficiaries';
+import { regions } from '@/db/schema/regions';
+import { eq, and, or, isNull, gt, sql, count, avg } from 'drizzle-orm';
+
+export async function GET() {
+  try {
+    const result = await db
+      .select({
+        regionCode: beneficiaries.regionCode,
+        regionName: regions.name,
+        regionLevel: regions.level,
+        count: count(),
+        centerLat: avg(beneficiaries.latitude),
+        centerLng: avg(beneficiaries.longitude),
+      })
+      .from(beneficiaries)
+      .innerJoin(regions, eq(beneficiaries.regionCode, regions.code))
+      .where(
+        and(
+          eq(beneficiaries.status, 'verified'),
+          or(
+            isNull(beneficiaries.expiresAt),
+            gt(beneficiaries.expiresAt, sql`NOW()`)
+          )
+        )
+      )
+      .groupBy(beneficiaries.regionCode, regions.name, regions.level)
+      .orderBy(sql`count(*) DESC`);
+
+    const data = result.map((row) => ({
+      regionCode: row.regionCode,
+      regionName: row.regionName,
+      regionLevel: row.regionLevel,
+      count: row.count,
+      centerLat: parseFloat(String(row.centerLat)),
+      centerLng: parseFloat(String(row.centerLng)),
+    }));
+
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error) {
+    console.error('Public map data error:', error);
+    return NextResponse.json(
+      { error: 'Gagal memuat data peta' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/public/map-data` — returns aggregated beneficiary count per region (GROUP BY region with COUNT and AVG for center coordinates)
- Add `GET /api/public/heatmap-data` — returns jittered `[lat, lng, intensity]` coordinates for leaflet.heat with ~300m random offset for privacy

Both endpoints are public (no auth required), filter by `status = 'verified'` and non-expired records, and return no PII.

Closes #23, Closes #24

## Test plan
- [ ] `curl http://localhost:3000/api/public/map-data` returns `{ data: [...] }` with region aggregates
- [ ] `curl http://localhost:3000/api/public/heatmap-data` returns `{ data: [[lat, lng, intensity], ...] }` with jittered coordinates
- [ ] Call heatmap-data twice — coordinates should differ between requests (jitter works)
- [ ] Empty database returns `{ data: [] }` — not an error
- [ ] No PII fields (nik, name, address, needs, verifiedById) in any response

🤖 Generated with [Claude Code](https://claude.com/claude-code)