### PR TITLE
feat: Add donatur dashboard with layout, statistics, and API endpoints

### DIFF
--- a/src/app/(dashboard)/donatur/layout.tsx
+++ b/src/app/(dashboard)/donatur/layout.tsx
@@ -5,19 +5,20 @@ import { ROLES } from '@/lib/constants';
 import DashboardSidebar, { MenuItem } from '@/components/layout/DashboardSidebar';
 
 // ============================================================
-// VERIFIKATOR MENU ITEMS
+// DONATUR MENU ITEMS
 // ============================================================
-const VERIFIKATOR_MENU: MenuItem[] = [
-  { label: 'Dashboard', path: '/verifikator', icon: 'home' },
-  { label: 'Input Data', path: '/verifikator/input', icon: 'plus' },
-  { label: 'Data Saya', path: '/verifikator/data-saya', icon: 'list' },
-  { label: 'Profile', path: '/verifikator/profile', icon: 'user' },
+const DONATUR_MENU: MenuItem[] = [
+  { label: 'Dashboard', path: '/donatur', icon: 'home' },
+  { label: 'Cari Target', path: '/donatur/cari-target', icon: 'search' },
+  { label: 'Permintaan Saya', path: '/donatur/permintaan-saya', icon: 'clipboard' },
+  { label: 'Penyaluran', path: '/donatur/penyaluran', icon: 'gift' },
+  { label: 'Profile', path: '/donatur/profile', icon: 'user' },
 ];
 
 // ============================================================
 // LAYOUT COMPONENT
 // ============================================================
-export default async function VerifikatorLayout({
+export default async function DonaturLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -25,18 +26,18 @@ export default async function VerifikatorLayout({
   // Auth check - get current user
   const user = await getCurrentUser();
 
-  // Redirect to unauthorized if not logged in or not a verifikator
+  // Redirect to unauthorized if not logged in or not a donatur
   if (!user) {
-    redirect('/login?callbackUrl=/verifikator');
+    redirect('/login?callbackUrl=/donatur');
   }
 
-  if (user.roles.includes(ROLES.VERIFIKATOR) === false) {
+  if (user.roles.includes(ROLES.DONATUR) === false) {
     redirect('/unauthorized');
   }
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <DashboardSidebar userName={user.name} menuItems={VERIFIKATOR_MENU} subtitle="Panel Verifikator" />
+      <DashboardSidebar userName={user.name} menuItems={DONATUR_MENU} subtitle="Panel Donatur" />
       <main className="md:ml-64 min-h-screen">
         <div className="p-6 md:p-8">{children}</div>
       </main>

--- a/src/app/(dashboard)/donatur/page.tsx
+++ b/src/app/(dashboard)/donatur/page.tsx
@@ -1,0 +1,246 @@
+import { getCurrentUser } from '@/lib/auth-utils';
+import { STATUS } from '@/lib/constants';
+import { getDonaturStatistics, getDonaturRecentRequests } from '@/services/donatur.service';
+
+// ============================================================
+// TYPES
+// ============================================================
+interface DashboardStats {
+  totalDonation: number;
+  activeDonations: number;
+  beneficiariesHelped: number;
+  completedDonations: number;
+}
+
+interface RecentRequest {
+  id: string;
+  beneficiaryName: string;
+  needs: string;
+  status: string;
+  createdAt: Date;
+}
+
+// ============================================================
+// STATUS BADGE COMPONENT
+// ============================================================
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-yellow-100 text-yellow-700',
+    approved: 'bg-green-100 text-green-700',
+    rejected: 'bg-red-100 text-red-700',
+  };
+
+  const labels: Record<string, string> = {
+    pending: 'Menunggu',
+    approved: 'Disetujui',
+    rejected: 'Ditolak',
+  };
+
+  const style = styles[status] ?? 'bg-gray-100 text-gray-700';
+  const label = labels[status] ?? status;
+
+  return (
+    <span className={`inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium ${style}`}>
+      {label}
+    </span>
+  );
+}
+
+// ============================================================
+// SVG ICONS
+// ============================================================
+function StatsIcon({ variant }: { variant: 'total' | 'active' | 'beneficiaries' | 'completed' }) {
+  const icons = {
+    total: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+      </svg>
+    ),
+    active: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+    beneficiaries: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+      </svg>
+    ),
+    completed: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  };
+
+  return icons[variant];
+}
+
+function EmptyIcon() {
+  return (
+    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+    </svg>
+  );
+}
+
+// ============================================================
+// PAGE COMPONENT
+// ============================================================
+export default async function DonaturDashboardPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return null;
+  }
+
+  // Fetch dashboard statistics
+  const stats: DashboardStats = await getDonaturStatistics(user.id);
+
+  // Fetch recent requests (limit 10)
+  const recentData: RecentRequest[] = await getDonaturRecentRequests(user.id, 10);
+
+  // ============================================================
+  // RENDER
+  // ============================================================
+  return (
+    <div>
+      {/* Welcome Header */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">
+          Selamat datang, {user.name}!
+        </h1>
+        <p className="text-gray-500 mt-1">
+          Berikut ringkasan aktivitas sedekah Anda.
+        </p>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        {/* Total Donasi */}
+        <div className="bg-white rounded-xl p-6 border border-gray-100">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-500 font-medium">Total Donasi</p>
+              <p className="text-3xl font-bold text-gray-900 mt-1">{stats.totalDonation}</p>
+            </div>
+            <div className="w-12 h-12 rounded-xl bg-primary/10 text-primary flex items-center justify-center">
+              <StatsIcon variant="total" />
+            </div>
+          </div>
+        </div>
+
+        {/* Donasi Aktif */}
+        <div className="bg-white rounded-xl p-6 border border-gray-100">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-500 font-medium">Donasi Aktif</p>
+              <p className="text-3xl font-bold text-gray-900 mt-1">{stats.activeDonations}</p>
+            </div>
+            <div className="w-12 h-12 rounded-xl bg-warning/10 text-warning flex items-center justify-center">
+              <StatsIcon variant="active" />
+            </div>
+          </div>
+        </div>
+
+        {/* Target Terbantu */}
+        <div className="bg-white rounded-xl p-6 border border-gray-100">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-500 font-medium">Target Terbantu</p>
+              <p className="text-3xl font-bold text-gray-900 mt-1">{stats.beneficiariesHelped}</p>
+            </div>
+            <div className="w-12 h-12 rounded-xl bg-success/10 text-success flex items-center justify-center">
+              <StatsIcon variant="beneficiaries" />
+            </div>
+          </div>
+        </div>
+
+        {/* Penyaluran Selesai */}
+        <div className="bg-white rounded-xl p-6 border border-gray-100">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-500 font-medium">Penyaluran Selesai</p>
+              <p className="text-3xl font-bold text-gray-900 mt-1">{stats.completedDonations}</p>
+            </div>
+            <div className="w-12 h-12 rounded-xl bg-info/10 text-info flex items-center justify-center">
+              <StatsIcon variant="completed" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Recent Requests Table */}
+      {recentData.length === 0 ? (
+        // Empty State
+        <div className="bg-white rounded-xl border border-gray-100 p-12 text-center">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gray-100 flex items-center justify-center text-gray-400">
+            <EmptyIcon />
+          </div>
+          <p className="text-gray-500 mb-2">Anda belum memiliki permintaan akses.</p>
+          <a
+            href="/donatur/cari-target"
+            className="text-primary hover:underline font-medium"
+          >
+            Cari target penerima manfaat
+          </a>
+        </div>
+      ) : (
+        // Table with data
+        <div className="bg-white rounded-xl border border-gray-100">
+          <div className="p-6 border-b border-gray-100 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900">Permintaan Terbaru</h2>
+            <a
+              href="/donatur/permintaan-saya"
+              className="text-sm text-primary hover:underline font-medium"
+            >
+              Lihat semua
+            </a>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="bg-gray-50">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Nama Penerima
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Kebutuhan
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Status
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Tanggal
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {recentData.map((item) => (
+                  <tr key={item.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 text-sm text-gray-900 font-medium">
+                      {item.beneficiaryName}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-600 max-w-[200px] truncate">
+                      {item.needs}
+                    </td>
+                    <td className="px-6 py-4">
+                      <StatusBadge status={item.status} />
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500">
+                      {new Date(item.createdAt).toLocaleDateString('id-ID', {
+                        day: 'numeric',
+                        month: 'short',
+                        year: 'numeric',
+                      })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/donatur/recent-requests/route.ts
+++ b/src/app/api/donatur/recent-requests/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth-utils';
+import { ROLES } from '@/lib/constants';
+import { getDonaturRecentRequests } from '@/services/donatur.service';
+
+// ============================================================
+// GET /api/donatur/recent-requests
+// Get recent access requests for the logged-in donatur
+// ============================================================
+export async function GET() {
+  try {
+    const user = await requireRole(ROLES.DONATUR);
+    const data = await getDonaturRecentRequests(user.id);
+
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error) {
+    console.error('Get recent requests error:', error);
+
+    // Handle auth errors
+    if (error instanceof Error) {
+      if (error.message.startsWith('UNAUTHORIZED')) {
+        return NextResponse.json(
+          { error: 'Anda harus login terlebih dahulu' },
+          { status: 401 }
+        );
+      }
+      if (error.message.startsWith('FORBIDDEN')) {
+        return NextResponse.json(
+          { error: 'Anda tidak memiliki akses' },
+          { status: 403 }
+        );
+      }
+    }
+
+    return NextResponse.json(
+      { error: 'Gagal memuat data permintaan terbaru' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/donatur/statistics/route.ts
+++ b/src/app/api/donatur/statistics/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth-utils';
+import { ROLES } from '@/lib/constants';
+import { getDonaturStatistics } from '@/services/donatur.service';
+
+// ============================================================
+// GET /api/donatur/statistics
+// Get statistics for the logged-in donatur
+// ============================================================
+export async function GET() {
+  try {
+    const user = await requireRole(ROLES.DONATUR);
+    const data = await getDonaturStatistics(user.id);
+
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error) {
+    console.error('Get donatur statistics error:', error);
+
+    // Handle auth errors
+    if (error instanceof Error) {
+      if (error.message.startsWith('UNAUTHORIZED')) {
+        return NextResponse.json(
+          { error: 'Anda harus login terlebih dahulu' },
+          { status: 401 }
+        );
+      }
+      if (error.message.startsWith('FORBIDDEN')) {
+        return NextResponse.json(
+          { error: 'Anda tidak memiliki akses' },
+          { status: 403 }
+        );
+      }
+    }
+
+    return NextResponse.json(
+      { error: 'Gagal memuat data statistik' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -8,7 +8,7 @@ import { signOut } from 'next-auth/react';
 // ============================================================
 // TYPES
 // ============================================================
-export type MenuIcon = 'home' | 'plus' | 'list' | 'user';
+export type MenuIcon = 'home' | 'plus' | 'list' | 'user' | 'search' | 'clipboard' | 'gift';
 
 export interface MenuItem {
   label: string;
@@ -19,6 +19,7 @@ export interface MenuItem {
 interface DashboardSidebarProps {
   userName: string;
   menuItems: MenuItem[];
+  subtitle?: string;
 }
 
 // ============================================================
@@ -44,6 +45,21 @@ function MenuIcon({ icon }: { icon: MenuIcon }) {
     user: (
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+      </svg>
+    ),
+    search: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+    ),
+    clipboard: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+    ),
+    gift: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7" />
       </svg>
     ),
   };
@@ -78,13 +94,15 @@ function CloseIcon() {
 // ============================================================
 // COMPONENT
 // ============================================================
-export default function DashboardSidebar({ userName, menuItems }: DashboardSidebarProps) {
+export default function DashboardSidebar({ userName, menuItems, subtitle }: DashboardSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
 
   const isActive = (item: MenuItem): boolean => {
-    // Exact match for root path
-    if (item.path === '/verifikator') {
+    // Determine base path from first menu item for exact matching
+    const basePath = menuItems[0]?.path ?? '';
+    // Exact match for base path (e.g., /verifikator or /donatur)
+    if (item.path === basePath) {
       return pathname === item.path;
     }
     // Starts with for sub-paths
@@ -130,7 +148,7 @@ export default function DashboardSidebar({ userName, menuItems }: DashboardSideb
           {/* Header */}
           <div className="p-6 border-b border-gray-100">
             <h1 className="text-xl font-bold text-primary">SedekahMap</h1>
-            <p className="text-xs text-gray-500 mt-1">Panel Verifikator</p>
+            {subtitle && <p className="text-xs text-gray-500 mt-1">{subtitle}</p>}
           </div>
 
           {/* Navigation */}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -25,6 +25,8 @@ export const API_ROUTES = {
   DONATUR_ACCESS_REQUESTS: '/api/donatur/access-requests',
   DONATUR_DISTRIBUTIONS: '/api/donatur/distributions',
   DONATUR_REVIEWS: '/api/donatur/reviews',
+  DONATUR_STATISTICS: '/api/donatur/statistics',
+  DONATUR_RECENT_REQUESTS: '/api/donatur/recent-requests',
 
   // Admin
   ADMIN_ACCESS_REQUESTS: '/api/admin/access-requests',

--- a/src/services/donatur.service.ts
+++ b/src/services/donatur.service.ts
@@ -1,0 +1,99 @@
+import { eq, and, desc, count, sql } from 'drizzle-orm';
+
+import { db } from '@/db';
+import { distributions } from '@/db/schema/distributions';
+import { accessRequests } from '@/db/schema/accessRequests';
+import { beneficiaries } from '@/db/schema/beneficiaries';
+import { STATUS } from '@/lib/constants';
+
+// ============================================================
+// TYPES
+// ============================================================
+export interface DonaturStatistics {
+  totalDonation: number;
+  activeDonations: number;
+  beneficiariesHelped: number;
+  completedDonations: number;
+}
+
+export interface DonaturRecentRequest {
+  id: string;
+  beneficiaryName: string;
+  needs: string;
+  status: string;
+  createdAt: Date;
+}
+
+// ============================================================
+// SERVICE FUNCTIONS
+// ============================================================
+
+/**
+ * getDonaturStatistics - Get statistics for a donatur
+ * @param userId - The donatur's user ID
+ * @returns Statistics object with donation counts
+ */
+export async function getDonaturStatistics(
+  userId: string
+): Promise<DonaturStatistics> {
+  // Get all statistics in a single query using conditional counts
+  const [statsResult] = await db
+    .select({
+      totalDonation: count(),
+      activeDonations: count(
+        sql`CASE WHEN ${distributions.status} = 'pending_proof' OR ${distributions.status} = 'pending_review' THEN 1 END`
+      ),
+      completedDonations: count(
+        sql`CASE WHEN ${distributions.status} = 'completed' THEN 1 END`
+      ),
+    })
+    .from(distributions)
+    .where(eq(distributions.donaturId, userId));
+
+  // Get distinct beneficiaries helped from completed distributions
+  const [beneficiariesResult] = await db
+    .select({
+      count: sql<number>`COUNT(DISTINCT ${distributions.beneficiaryId})`,
+    })
+    .from(distributions)
+    .where(
+      and(
+        eq(distributions.donaturId, userId),
+        eq(distributions.status, STATUS.DISTRIBUTION.COMPLETED)
+      )
+    );
+
+  return {
+    totalDonation: statsResult?.totalDonation ?? 0,
+    activeDonations: statsResult?.activeDonations ?? 0,
+    beneficiariesHelped: beneficiariesResult?.count ?? 0,
+    completedDonations: statsResult?.completedDonations ?? 0,
+  };
+}
+
+/**
+ * getDonaturRecentRequests - Get recent access requests for a donatur
+ * @param userId - The donatur's user ID
+ * @param limit - Maximum number of requests to return (default: 10)
+ * @returns Array of recent requests with beneficiary information
+ */
+export async function getDonaturRecentRequests(
+  userId: string,
+  limit: number = 10
+): Promise<DonaturRecentRequest[]> {
+  const results = await db
+    .select({
+      id: accessRequests.id,
+      beneficiaryName: beneficiaries.name,
+      needs: beneficiaries.needs,
+      status: accessRequests.status,
+      createdAt: accessRequests.createdAt,
+    })
+    .from(accessRequests)
+    .innerJoin(beneficiaries, eq(accessRequests.beneficiaryId, beneficiaries.id))
+    .where(eq(accessRequests.donaturId, userId))
+    .orderBy(desc(accessRequests.createdAt))
+    .limit(limit);
+
+  return results;
+}


### PR DESCRIPTION
## Summary

This PR implements the donatur (donor) dashboard feature as described in Issues #47, #48, and #49.

### Changes

- **DashboardSidebar Refactor**: Made the sidebar reusable across roles by adding a `subtitle` prop and fixing the `isActive()` function to be dynamic. Added new icons for donatur menu items (search, clipboard, gift).

- **Donatur Constants**: Added `DONATUR_STATISTICS` and `DONATUR_RECENT_REQUESTS` to `API_ROUTES`.

- **Donatur Service Layer**: Created `src/services/donatur.service.ts` with:
  - `getDonaturStatistics()` - Returns total, active, completed donations and beneficiaries helped
  - `getDonaturRecentRequests()` - Returns recent access requests with beneficiary details

- **API Endpoints**:
  - `GET /api/donatur/statistics` - Returns donatur statistics
  - `GET /api/donatur/recent-requests` - Returns recent access requests

- **Donatur Dashboard Layout** (`/donatur`):
  - Protected route (donatur role only)
  - 5 menu items: Dashboard, Cari Target, Permintaan Saya, Penyaluran, Profile
  - Sidebar with "Panel Donatur" subtitle

- **Donatur Dashboard Homepage** (`/donatur`):
  - 4 stat cards: Total Donasi, Donasi Aktif, Target Terbantu, Penyaluran Selesai
  - Recent requests table with status badges
  - Empty state with CTA to "Cari target"

## Test plan

- [ ] Login as donatur (`donatur@sedekahmap.id / donatur123`) - redirects to `/donatur`
- [ ] Verify sidebar renders with all 5 menu items and "Panel Donatur" subtitle
- [ ] Verify stat cards display correctly
- [ ] Verify recent requests table shows data
- [ ] Login as verifikator - verify verifikator dashboard still works unchanged
- [ ] Test `/api/donatur/statistics` endpoint returns correct data
- [ ] Test `/api/donatur/recent-requests` endpoint returns correct data
- [ ] Verify role protection - non-donatur users cannot access `/donatur/*`

Closes #47, #48, #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)