### PR TITLE
feat: API Route — GET List Distributions

### DIFF
--- a/src/app/api/admin/distributions/route.ts
+++ b/src/app/api/admin/distributions/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requirePermission } from '@/lib/auth-utils';
+import { PERMISSIONS, STATUS } from '@/lib/constants';
+import { getDistributions } from '@/services/distribution.service';
+
+// ============================================================
+// GET /api/admin/distributions
+// List all distributions (admin only)
+// ============================================================
+
+export async function GET(request: NextRequest) {
+  try {
+    // Auth & permission check
+    await requirePermission(PERMISSIONS.DISTRIBUTION_READ);
+
+    const { searchParams } = new URL(request.url);
+    const status = (searchParams.get('status') as
+      | 'pending_proof'
+      | 'pending_review'
+      | 'completed'
+      | 'rejected') || STATUS.DISTRIBUTION.PENDING_REVIEW;
+    const limit = parseInt(searchParams.get('limit') || '20', 10);
+    const offset = parseInt(searchParams.get('offset') || '0', 10);
+
+    // Call service
+    const result = await getDistributions({ status, limit, offset });
+
+    return NextResponse.json(
+      {
+        data: result.data,
+        pagination: {
+          limit,
+          offset,
+          total: result.total,
+        },
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Get distributions error:', error);
+
+    if (error instanceof Error) {
+      if (error.message.startsWith('UNAUTHORIZED')) {
+        return NextResponse.json(
+          { error: 'Anda harus login terlebih dahulu' },
+          { status: 401 }
+        );
+      }
+
+      if (error.message.startsWith('FORBIDDEN')) {
+        return NextResponse.json(
+          { error: 'Anda tidak memiliki akses' },
+          { status: 403 }
+        );
+      }
+    }
+
+    return NextResponse.json(
+      { error: 'Gagal memuat data distribusi' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/admin/distributions` endpoint for listing distributions with status filter and pagination
- Requires `distribution:read` permission (401 if unauthenticated, 403 if unauthorized)
- Default status filter: `pending_review`; supports `status`, `limit` (default 20), `offset` (default 0) query params
- Response format: `{ data: [...], pagination: { limit, offset, total } }`

Closes #57

## Test plan
- [ ] `GET /api/admin/distributions` returns list with default status `pending_review`
- [ ] `GET /api/admin/distributions?status=completed` filters by status
- [ ] `GET /api/admin/distributions?limit=10&offset=20` pagination works
- [ ] Unauthenticated request returns 401
- [ ] User without `distribution:read` permission returns 403
- [ ] TypeScript compilation passes (`tsc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)